### PR TITLE
Feat/crud1

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Articles controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,0 +1,48 @@
+class ArticlesController < ApplicationController
+    def index
+      @articles = Article.all
+    end
+  
+    def show
+      @article = Article.find(params[:id])
+    end
+  
+    def new
+      @article = Article.new
+    end
+  
+    def create
+      @article = Article.new(article_params)
+      if @article.save
+        redirect_to @article
+      else
+        render :new
+      end
+    end
+  
+    def edit
+      @article = Article.find(params[:id])
+    end
+  
+    def update
+      @article = Article.find(params[:id])
+      if @article.update(article_params)
+        redirect_to @article
+      else
+        render :edit
+      end
+    end
+  
+    def destroy
+      @article = Article.find(params[:id])
+      @article.destroy
+      redirect_to articles_path
+    end
+  
+    private
+  
+    def article_params
+      params.require(:article).permit(:title, :content, :image_url)
+    end
+  end
+  

--- a/app/controllers/dash_boards_controller.rb
+++ b/app/controllers/dash_boards_controller.rb
@@ -1,8 +1,0 @@
-class DashBoardsController < ApplicationController
-    before_action :authenticate_user!
-  
-    def index
-      # ダッシュボードのロジックをここに書きます
-    end
-  end
-  

--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -1,6 +1,8 @@
 # app/controllers/users/articles_controller.rb
 module Users
-    class ArticlesController < ApplicationController
+  class ArticlesController < ApplicationController
+    before_action :authenticate_user! # ログインユーザーのみを許可する
+
       def index
         @articles = Article.all
       end

--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -1,0 +1,54 @@
+# app/controllers/users/articles_controller.rb
+module Users
+    class ArticlesController < ApplicationController
+      def index
+        @articles = Article.all
+      end
+    
+      def show
+        @article = Article.find(params[:id])
+      end
+    
+      def new
+        @article = Article.new
+      end
+    
+      def create
+        @article = Article.new(article_params)
+        if @article.save
+          redirect_to users_article_path(@article), notice: 'Article was successfully created.'
+        else
+          render :new
+        end
+      end
+      
+    
+      def edit
+        @article = Article.find(params[:id])
+      end
+    
+      def update
+        @article = Article.find(params[:id])
+        if @article.update(article_params)
+          redirect_to users_article_path(@article)
+        else
+          render :edit
+        end
+      end
+
+      def destroy
+        @article = Article.find(params[:id])
+        @article.destroy
+        redirect_to users_articles_path, notice: 'Article was successfully destroyed.'
+      end
+      
+      
+    
+      private
+    
+      def article_params
+        params.require(:article).permit(:title, :content, :image_url, :image_file)
+      end
+    end
+  end
+  

--- a/app/controllers/users/dash_boards_controller.rb
+++ b/app/controllers/users/dash_boards_controller.rb
@@ -1,0 +1,9 @@
+# app/controllers/users/dash_boards_controller.rb
+
+class Users::DashBoardsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    # ダッシュボードのコードをここに追加する
+  end
+end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,0 +1,2 @@
+module ArticlesHelper
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,8 @@
+class Article < ApplicationRecord
+    validates :title, presence: true, length: { maximum: 10 }
+    validates :content, presence: true
+  
+    # Active Storageを使用して画像ファイルを扱うための関連を追加する
+    has_one_attached :image_file
+  end
+  

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -2,6 +2,7 @@
 <p class="mb-4 text-center">sample</p>
 
 <div class="actions d-flex flex-column justify-content-center align-items-center">
-  <%= link_to '編集', edit_user_registration_path, class: 'btn btn-primary me-2 w-50 mb-2' %>
+  <%= link_to '記事一覧', users_articles_path, class: 'btn btn-primary mb-2 w-50' %>
+  <%= link_to '編集', edit_user_registration_path, class: 'btn btn-primary me-2 mb-2 w-50' %>
   <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { confirm: '本当にログアウトしますか？' }, class: 'btn btn-warning w-50' %>
 </div>

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -1,8 +1,0 @@
-<h1 class="mb-4 text-center">Dash Boards</h1>
-<p class="mb-4 text-center">sample</p>
-
-<div class="actions d-flex flex-column justify-content-center align-items-center">
-  <%= link_to '記事一覧', users_articles_path, class: 'btn btn-primary mb-2 w-50' %>
-  <%= link_to '編集', edit_user_registration_path, class: 'btn btn-primary me-2 mb-2 w-50' %>
-  <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { confirm: '本当にログアウトしますか？' }, class: 'btn btn-warning w-50' %>
-</div>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t('mailer.welcome', email: @resource.email) %></p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t('mailer.confirm_instruction') %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t('mailer.confirm_account'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,8 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-lg-8">
+      <p class="mb-4 text-center">アカウントの有効化について数分以内にメールでご連絡します。</p> 
+
       <h2 class="mb-4 text-center"><%= t('devise.sessions.new.log_in') %></h2>
 
       <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'needs-validation', novalidate: true }) do |f| %>

--- a/app/views/users/articles/edit.html.erb
+++ b/app/views/users/articles/edit.html.erb
@@ -1,0 +1,25 @@
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <h1 class="text-center">記事の編集</h1>
+      <%= form_for @article, url: users_article_path(@article), method: :patch, html: { class: "form" } do |form| %>
+        <div class="form-group">
+          <%= form.label :title, class: "control-label" %>
+          <%= form.text_field :title, class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= form.label :content, class: "control-label" %>
+          <%= form.text_area :content, class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= form.label :image_file, class: "control-label" %>
+          <%= form.file_field :image_file, class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= form.submit "更新する", class: "btn btn-primary" %>
+        </div>
+        <% end %>
+        <%= link_to '戻る', users_article_path(@article), class: "btn btn-secondary" %>
+      </div>
+    </div>
+  </div>

--- a/app/views/users/articles/edit.html.erb
+++ b/app/views/users/articles/edit.html.erb
@@ -4,22 +4,28 @@
       <h1 class="text-center">記事の編集</h1>
       <%= form_for @article, url: users_article_path(@article), method: :patch, html: { class: "form" } do |form| %>
         <div class="form-group">
-          <%= form.label :title, class: "control-label" %>
+          <%= form.label :タイトル, class: "control-label" %>
           <%= form.text_field :title, class: "form-control" %>
         </div>
         <div class="form-group">
-          <%= form.label :content, class: "control-label" %>
+          <%= form.label :内容, class: "control-label" %>
           <%= form.text_area :content, class: "form-control" %>
         </div>
         <div class="form-group">
-          <%= form.label :image_file, class: "control-label" %>
-          <%= form.file_field :image_file, class: "form-control" %>
+          <%= form.label :画像, class: "control-label" %>
+
+          <%= form.file_field :image_file %>
+
+
+
         </div>
-        <div class="form-group">
+        <div class="text-center mt-3"> <!-- 上下の余白を追加 -->
           <%= form.submit "更新する", class: "btn btn-primary" %>
         </div>
         <% end %>
-        <%= link_to '戻る', users_article_path(@article), class: "btn btn-secondary" %>
+
+
+        <%= link_to '戻る', users_article_path(@article) %>
       </div>
     </div>
   </div>

--- a/app/views/users/articles/index.html.erb
+++ b/app/views/users/articles/index.html.erb
@@ -28,10 +28,7 @@
             <div class="text-center"> <!-- 画像を中央揃えにする -->
               <%= image_tag url_for(article.image_file), size: "2x" %>
             </div>
-            
-          <% else %>
-            <p>画像なし</p>
-          <% end %>
+          <% end %> <!-- 画像がない場合は何も表示しない -->
         </td>
         <td class="text-center">
           <%= link_to '編集', edit_users_article_path(article), class: 'btn btn-success' %>

--- a/app/views/users/articles/index.html.erb
+++ b/app/views/users/articles/index.html.erb
@@ -1,0 +1,43 @@
+<h1 class="text-center">記事一覧</h1>
+<div class="container">
+  <div class="row justify-content-center"> <!-- 中央に配置 -->
+    <div class="col-md-6 text-center"> <!-- 幅を指定して中央に配置 -->
+      <%= link_to '記事新規作成', new_users_article_path, class: 'btn btn-primary btn-block' %>
+    </div>
+  </div>
+</div>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>詳細表示</th>
+      <th>タイトル</th>
+      <th>内容</th>
+      <th class="text-center">画像</th>
+      <th class="text-center">編集・削除</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @articles.each do |article| %>
+      <tr>
+        <td><%= link_to '詳細', users_article_path(article), class: 'btn btn-primary' %></td>
+        <td><%= article.title %></td>
+        <td><%= article.content %></td>
+        <td class="text-center">
+          <% if article.image_file.attached? %>
+            <div class="text-center"> <!-- 画像を中央揃えにする -->
+              <%= image_tag url_for(article.image_file), size: "2x" %>
+            </div>
+            
+          <% else %>
+            <p>画像なし</p>
+          <% end %>
+        </td>
+        <td class="text-center">
+          <%= link_to '編集', edit_users_article_path(article), class: 'btn btn-success' %>
+          <%= link_to '削除', users_article_path(article), method: :delete, data: { confirm: '本当に削除しますか?' }, class: 'btn btn-danger' %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/users/articles/new.html.erb
+++ b/app/views/users/articles/new.html.erb
@@ -1,0 +1,23 @@
+<!-- app/views/users/articles/new.html.erb -->
+<h1>New Article</h1>
+<%= form_with(model: @article, url: users_articles_path, local: true) do |form| %>
+  <div>
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+  <div>
+    <%= form.label :content %>
+    <%= form.text_area :content %>
+  </div>
+  <div>
+    <%= form.label :image_url %>
+    <%= form.text_field :image_url %>
+  </div>
+  <div>
+    <%= form.label :image_file %>
+    <%= form.file_field :image_file %>
+  </div>
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/users/articles/new.html.erb
+++ b/app/views/users/articles/new.html.erb
@@ -1,23 +1,28 @@
 <!-- app/views/users/articles/new.html.erb -->
-<h1>New Article</h1>
-<%= form_with(model: @article, url: users_articles_path, local: true) do |form| %>
-  <div>
-    <%= form.label :title %>
-    <%= form.text_field :title %>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <h1 class="text-center">記事の新規作成</h1>
+      <%= form_with(model: @article, url: users_articles_path, local: true, html: { class: "form" }) do |form| %>
+        <div class="form-group">
+          <%= form.label :title, "タイトル", class: "control-label" %>
+          <%= form.text_field :title, class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= form.label :content, "内容", class: "control-label" %>
+          <%= form.text_area :content, class: "form-control" %>
+        </div>
+画像<br>
+<%= form.file_field :image_file %>
+
+        <div class="form-group text-center"><br>
+          <%= form.submit "新規作成", class: "btn btn-primary mb-3" %>
+        </div>
+      <% end %>
+      <div class="text-left mt-4">
+      <%= link_to '戻る', users_articles_path %>
+    </div>
+    
+    </div>
   </div>
-  <div>
-    <%= form.label :content %>
-    <%= form.text_area :content %>
-  </div>
-  <div>
-    <%= form.label :image_url %>
-    <%= form.text_field :image_url %>
-  </div>
-  <div>
-    <%= form.label :image_file %>
-    <%= form.file_field :image_file %>
-  </div>
-  <div>
-    <%= form.submit %>
-  </div>
-<% end %>
+</div>

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -1,0 +1,38 @@
+<h1 class="text-center">記事詳細</h1>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>タイトル</th>
+      <th>内容</th>
+      <th class="text-center">画像</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><%= @article.title %></td>
+      <td><%= @article.content %></td>
+      <td class="text-center">
+        <% if @article.image_file.attached? %>
+          <%= image_tag url_for(@article.image_file), class: "img-fluid" %>
+        <% else %>
+          画像なし
+        <% end %>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="container text-center">
+  <div class="row">
+  <div class="col-md-8 offset-md-2">
+  <%= link_to '編集', edit_users_article_path(@article), class: "btn btn-success" %>
+  <%= link_to '削除', users_article_path(@article), method: :delete, data: { confirm: '本当に削除しますか?' }, class: "btn btn-danger" %>
+</div>
+</div>
+  <div class="row mt-3">
+    <div class="col-md-8 offset-md-2">
+      <%= link_to '記事一覧に戻る', users_articles_path, class: "btn btn-primary" %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -32,7 +32,7 @@
 </div>
   <div class="row mt-3">
     <div class="col-md-8 offset-md-2">
-      <%= link_to '記事一覧に戻る', users_articles_path, class: "btn btn-primary" %>
+      <%= link_to '記事一覧へ戻る', users_articles_path, class: "btn btn-primary" %>
     </div>
   </div>
 </div>

--- a/app/views/users/dash_boards/index.html.erb
+++ b/app/views/users/dash_boards/index.html.erb
@@ -1,0 +1,8 @@
+<h1 class="mb-4 text-center">Dash Boards</h1>
+<p class="mb-4 text-center" style="font-size: 40px;">sample</p>
+
+<div class="actions d-flex flex-column justify-content-center align-items-center">
+  <%= link_to '記事一覧', users_articles_path, class: 'btn btn-primary mb-2 w-50' %>
+  <%= link_to '編集', edit_user_registration_path, class: 'btn btn-primary mb-2 w-50' %>
+  <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { confirm: '本当にログアウトしますか？' }, class: 'btn btn-warning mb-2 w-50' %>
+</div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -28,7 +28,12 @@ ja:
         subject: "パスワード変更の指示"
       unlock_instructions:
         subject: "アカウントロック解除の指示"
-
+      confirmation_instructions:
+        subject: "メールアドレス確認メール"
+      email_changed:
+        subject: "メールアドレス変更通知"
+      password_change:
+        subject: "パスワード変更通知"
   errors:
     messages:
       not_saved:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,11 +3,13 @@ ja:
     attributes:
       user:
         name: "名前"
-        email: "Eメール"
+        email: "メールアドレス"
         password: "パスワード"
+        remember_me: "次回から自動的にログイン"
         password_confirmation: "パスワード（確認用）"
         current_password: "現在のパスワード"
         confirm_new_password: "パスワード（確認用）"
+        
   helpers:
     submit:
       user:
@@ -82,3 +84,10 @@ ja:
       not_saved:
         one: "エラーが発生したため %{resource} は保存されませんでした。"
         other: "エラーが発生したため %{resource} は保存されませんでした。"
+
+
+  mailer:
+    welcome:  "%{email}様"
+    confirm_instruction: "以下のリンクをクリックし、メールアドレスの確認手続きを完了させてください。"
+    confirm_account: "メールアドレスの確認"
+    

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,30 +8,30 @@ Rails.application.routes.draw do
 
   # Routes for authenticated users
   authenticated :user do
-    root to: 'dash_boards#index', as: :authenticated_root
-    get 'dash_boards', to: 'dash_boards#index', as: :users_dash_boards
+    root to: 'users/dash_boards#index', as: :authenticated_root
+    # Updated routes to use the users namespace
+    get 'dash_boards', to: 'users/dash_boards#index', as: :users_dash_boards
     delete 'logout', to: 'devise/sessions#destroy', as: :logout
   end
 
   # Other routes
-  resources :dash_boards, only: [:index]
-  
+  # Removed duplicate and unnecessary route for dash_boards
+  # resources :dash_boards, only: [:index]
+
   # Letter Opener Web for development environment
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 
+  # Devise scope for unauthenticated users
   devise_scope :user do
     root to: 'devise/sessions#new'
   end
 
-# routes.rb
-
-namespace :users do
-  resources :articles, only: [:index, :show, :new, :create, :edit, :update, :destroy]
-end
-
-
-
-
+  # Users namespace
+  namespace :users do
+    resources :articles, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+    # Corrected users_dash_boards route within users namespace
+    resources :dash_boards, only: [:index]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,13 +9,13 @@ Rails.application.routes.draw do
   # Routes for authenticated users
   authenticated :user do
     root to: 'dash_boards#index', as: :authenticated_root
-    get 'users/dash_boards', to: 'dash_boards#index', as: :users_dash_boards
+    get 'dash_boards', to: 'dash_boards#index', as: :users_dash_boards
     delete 'logout', to: 'devise/sessions#destroy', as: :logout
   end
 
   # Other routes
   resources :dash_boards, only: [:index]
-
+  
   # Letter Opener Web for development environment
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
@@ -24,4 +24,14 @@ Rails.application.routes.draw do
   devise_scope :user do
     root to: 'devise/sessions#new'
   end
+
+# routes.rb
+
+namespace :users do
+  resources :articles, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+end
+
+
+
+
 end

--- a/db/migrate/20240606121721_create_articles.rb
+++ b/db/migrate/20240606121721_create_articles.rb
@@ -1,0 +1,11 @@
+class CreateArticles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :articles do |t|
+      t.string :title, limit: 10
+      t.text :content
+      t.string :image_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240606122835_change_article_columns.rb
+++ b/db/migrate/20240606122835_change_article_columns.rb
@@ -1,0 +1,6 @@
+class ChangeArticleColumns < ActiveRecord::Migration[6.1]
+  def change
+    change_column :articles, :title, :string, limit: 10, null: false
+    change_column :articles, :content, :text, null: false
+  end
+end

--- a/db/migrate/20240606133956_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20240606133956_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,48 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,43 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_18_134412) do
+ActiveRecord::Schema.define(version: 2024_06_06_133956) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "articles", force: :cascade do |t|
+    t.string "title", limit: 10, null: false
+    t.text "content", null: false
+    t.string "image_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -39,4 +75,6 @@ ActiveRecord::Schema.define(version: 2024_05_18_134412) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ArticlesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  content: MyText
+  image_url: MyString
+
+two:
+  title: MyString
+  content: MyText
+  image_url: MyString

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ArticleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### PR概要
mainブランチから作業ブランチ(feat/crud1)を切って作業すること
"記事テーブル(article)を作成すること。カラムは以下の通り。
id: 主キー
title: string型, タイトル, not_null制約, 10文字以内
content: text型, 本文, not_null制約
画像のカラム（自分で考える）"
記事の投稿に画像を1枚添付できるようにすること
"users/article_controllerを作成してCRUD機能を作ること（アクションは以下の通り）
index(一覧画面)
show(詳細画面)
new(新規作成画面)
create(新規作成処理)
edit(編集画面)
update(更新処理)
destroy(削除処理)"
画面遷移とサンプル画面は以下のリンクの画面遷移と画面イメージのようになっていること
https://drive.mindmup.com/map/1px1JibPFvo3NJeqobtLC9ZYrxZV7FCrh
users/articles_controllerの処理はログインユーザーのみ受け付けること
ログインユーザーでなければユーザーログイン画面にリダイレクトすること
### 実装画面スクショを添付したスプシのリンク
https://docs.google.com/spreadsheets/d/1K1v3fIZ-fSAWiNYhGGIUY3Gr4PtN9gfJYcRsmtwIbNU/edit#gid=689648848
